### PR TITLE
fix/remove $ from install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ This package adds a `.twig` template engine to Eleventy that lets you use the pu
 
 Install the latest `@factorial/eleventy-plugin-twig` release as a `node_module` with `yarn`:
 
-```shellsession
-$ yarn add --dev @factorial/eleventy-plugin-twig
+```sh
+yarn add --dev @factorial/eleventy-plugin-twig
 ```
 
 or `npm`:
 
-```shellsession
-$ npm install --save-dev @factorial/eleventy-plugin-twig
+```sh
+npm install --save-dev @factorial/eleventy-plugin-twig
 ```
 
 ## Usage


### PR DESCRIPTION
GitHub puts a handy "Copy" button next to code blocks. Copy+paste for commands is easier if they don't include the $ sign. Also, users unfamiliar with the terminal might be confused when they copy and paste a command with a $ sign and it doesn't work.