### PR TITLE
fix/remove allowInlineIncludes which causes caching errors

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -126,9 +126,6 @@ module.exports = (eleventyConfig, userOptions) => {
         path: `./${inputPath}`,
         // @ts-ignore somehow the namespace type is not part of the interface
         // provided for twig via @types
-        allowInlineIncludes: true,
-        // @ts-ignore somehow the namespace type is not part of the interface
-        // provided for twig via @types
         namespaces: userOptions.twig?.namespaces || {},
       });
       // @ts-ignore somehow a promise is defined in the interface


### PR DESCRIPTION
`allowInlineIncludes` causes caching problems see #18. 

Currently there is no use-case for inline includes and include/extends is working as expected without that option set.