### PR TITLE
fix: add trailing slash to assets_path()

### DIFF
--- a/lib/shortcodes/assetPath.js
+++ b/lib/shortcodes/assetPath.js
@@ -6,5 +6,5 @@
  * @returns {string}
  */
 module.exports = (eleventyConfig, userOptions) => {
-  return userOptions.assets.base;
+  return `/${userOptions.assets.base}`;
 };


### PR DESCRIPTION
Until issue #28 is solved properly we have to add a trailing slash to the assets_path to access the assets independend from the current path