### PR TITLE
fix(shortcodes/image): explicit disable useCache

### DIFF
--- a/lib/shortcodes/image.js
+++ b/lib/shortcodes/image.js
@@ -79,6 +79,7 @@ module.exports = (eleventyConfig, userOptions, filename, alt, classes) => {
       userOptions.assets.base,
       userOptions.assets.images
     ),
+    useCache: false,
     urlPath: `/${userOptions.assets.base}/${userOptions.assets.images}`,
   };
   const currentPath = path.join(


### PR DESCRIPTION
To avoid any caching problems the useCache is disabled explicit. Solves #32 

**Watchout:** This is just a temp solutions and must be refactored after the shortcodes cleanup currently in the making.