### PR TITLE
feat: Make mixManifest optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ As mentioned in the `eleventyConfig.addPlugin(eleventy-plugin-twig, USER_OPTIONS
 
 /**
  * @typedef {object} USER_OPTIONS
- * @property {string} mixManifest - path to the mixManifest file relative to the build folder
+ * @property {string} [mixManifest] - path to the mixManifest file relative to the build folder
  * @property {ASSETS} [assets] - where to find all the assets relative to the build folder
  * @property {IMAGES} [images] - options for Eleventys image processing
  * @property {ELEVENTY_DIRECTORIES} dir - Eleventy folder decisions

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -67,20 +67,18 @@ const handleErrors = (userOptions) => {
     );
   }
 
-  if (!userOptions.mixManifest) {
-    errors.push("userOptions.mixManifest is not defined.");
-  }
+  if (userOptions.mixManifest) {
+    if (!userOptions.mixManifest.match(/^[\w-_]+.json$/)) {
+      errors.push(
+        "userOptions.mixManifest does not provide a valid filename (for example 'foobar.json')."
+      );
+    }
 
-  if (!userOptions.mixManifest?.match(/^[\w-_]+.json$/)) {
-    errors.push(
-      "userOptions.mixManifest does not provide a valid filename (for example 'foobar.json')."
-    );
-  }
-
-  if (userOptions.mixManifest && !userOptions.assets?.base) {
-    errors.push(
-      "userOptions.mixManifest requires userOptions.assets.base to be defined."
-    );
+    if (!userOptions.assets?.base) {
+      errors.push(
+        "userOptions.mixManifest requires userOptions.assets.base to be defined."
+      );
+    }
   }
 
   if (!userOptions.dir) {

--- a/lib/shortcodes/mix.js
+++ b/lib/shortcodes/mix.js
@@ -10,6 +10,8 @@ const fs = require("fs");
  * @returns {string}
  */
 module.exports = (eleventyConfig, userOptions, originalAsset) => {
+  if (!userOptions.mixManifest) return originalAsset;
+
   const mix = JSON.parse(
     fs.readFileSync(
       `./${userOptions.dir.output}/${userOptions.mixManifest}`,


### PR DESCRIPTION
Currently the plugin throws an error when `mixManifest` is not defined. In my use case currently I do not want hashed assets though, so I need the plugin to allow not using a manifest.